### PR TITLE
Keep vendor cell_id in spatial_unlabelled as a segmentation prior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## NEW FUNCTIONALITY
 
-* ...
+* Preserve the vendor `cell_id` on transcripts in `spatial_unlabelled` as an optional segmentation prior, instead of stripping it together with the held-out ground-truth columns. Declared as an optional integer column in `src/api/file_spatial_unlabelled.yaml`.
 
 ## MAJOR CHANGES
 

--- a/src/api/file_spatial_unlabelled.yaml
+++ b/src/api/file_spatial_unlabelled.yaml
@@ -47,6 +47,14 @@ info:
             name: overlaps_nucleus
             required: false
             description: Whether the point overlaps with the nucleus (derived from morphology)
+          - type: integer
+            name: cell_id
+            required: false
+            description: |
+              Vendor-provided cell assignment from the raw data, exposed as a
+              segmentation prior. This is NOT the ground truth used for
+              evaluation (which is held out in spatial_solution); methods may
+              freely condition on it.
     tables:
       - type: anndata
         name: "table"

--- a/src/data_processors/process_dataset/script.py
+++ b/src/data_processors/process_dataset/script.py
@@ -92,8 +92,11 @@ dataset_uns = {
 # ---------------------------------------------------------------
 print(">> Building spatial dataset for methods (no ground truth)", flush=True)
 
-# Strip columns that reveal ground truth cell assignments from transcripts
-_GROUND_TRUTH_COLS = {"cell_id", "nucleus_id", "cell_type"}
+# Strip ground-truth-revealing columns, but keep the vendor `cell_id` as a
+# segmentation prior — most methods (e.g. segger) condition on the vendor's
+# morphology-based assignment without treating it as ground truth. The held-out
+# ground truth used for evaluation lives in spatial_solution, not here.
+_GROUND_TRUTH_COLS = {"nucleus_id", "cell_type"}
 transcripts = sp_data.points["transcripts"]
 clean_transcript_cols = [c for c in transcripts.columns if c not in _GROUND_TRUTH_COLS]
 clean_transcripts = transcripts[clean_transcript_cols]


### PR DESCRIPTION
  ## Summary

  - Stop stripping the vendor `cell_id` (e.g. Xenium morphology cell id) from transcripts when building `spatial_unlabelled`. Methods
  like segger use it as a prior, not as ground truth.
  - Declare `cell_id` as an optional integer column on the unlabelled transcripts in `src/api/file_spatial_unlabelled.yaml`.
  - Held-out ground truth used for evaluation continues to live exclusively in `spatial_solution`; only `nucleus_id` and `cell_type`
  remain stripped.

  ## Test plan

  - [ ] `viash test src/data_processors/process_dataset/config.vsh.yaml` passes on a Xenium test dataset
  - [ ] Resulting `spatial_unlabelled.zarr` contains a `cell_id` column on `points["transcripts"]`
  - [ ] `spatial_solution.zarr` is unchanged
  - [ ] At least one method (segger / cellpose) runs end-to-end against the new unlabelled output

  I have performed a self-review of my code

  **Check the correct box. Does this PR contain:**

  - [ ] Breaking changes
  - [x] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes
  - [x] Proposed changes are described in the `CHANGELOG.md`

  - [ ] CI Tests succeed and look good!

  Notes for honesty:
  - "CI Tests succeed and look good!" is left unchecked — I couldn't run CI locally (no Docker / viash here). Check it once GitHub
  Actions goes green.
  - Not breaking: the column is optional, methods that don't read it are unaffected.