### PR TITLE
Add hne gt metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## NEW FUNCTIONALITY
 
+* Add three new benchmarking metrics: **ASR** (Assignment Specificity Ratio) for liver zonation, **Marker Specificity** for cell-type transcript assignment, and **Mitotic Specificity** for mitotic cell marker evaluation. All three are wired into the `run_benchmark` workflow.
+* Extend `file_common_ist.yaml` and `file_spatial_solution.yaml` schemas with optional `pa_boundaries`/`cv_boundaries` for liver zonation landmarks.
+* Propagate `groundtruth_cell_type` from `tenx_xenium_groundtruth` loader through `process_dataset` to `spatial_solution`.
 * Preserve the vendor `cell_id` on transcripts in `spatial_unlabelled` as an optional segmentation prior, instead of stripping it together with the held-out ground-truth columns. Declared as an optional integer column in `src/api/file_spatial_unlabelled.yaml`.
 
 ## MAJOR CHANGES

--- a/src/api/file_common_ist.yaml
+++ b/src/api/file_common_ist.yaml
@@ -110,6 +110,40 @@ info:
             name: "geometry"
             required: true
             description: Geometry of the nucleus boundary
+      - type: dataframe
+        name: "pa_boundaries"
+        description: >
+          Optional — Portal Area (PA) polygon annotations in µm intrinsic
+          coordinates, derived from manual pathologist annotation of the
+          morphology image.  Present only for liver datasets processed with
+          liver_zonation/migrate_annotations.py.  Used by the ASR metric to
+          compute per-cell distances to the nearest periportal zone boundary.
+        required: false
+        columns:
+          - type: object
+            name: "geometry"
+            required: true
+            description: >
+              Shapely Polygon in µm intrinsic coordinates.  The associated
+              zarr group stores a scale transform (1/pixel_size) so that
+              sd.transform(..., to_coordinate_system="global") returns
+              coordinates in pixel space, consistent with the morphology image.
+      - type: dataframe
+        name: "cv_boundaries"
+        description: >
+          Optional — Central Vein (CV) polygon annotations in µm intrinsic
+          coordinates, derived from manual pathologist annotation.  Present
+          only for liver datasets processed with
+          liver_zonation/migrate_annotations.py.  Used together with
+          pa_boundaries by the ASR metric for landmark-proximity filtering.
+        required: false
+        columns:
+          - type: object
+            name: "geometry"
+            required: true
+            description: >
+              Shapely Polygon in µm intrinsic coordinates, same coordinate
+              convention as pa_boundaries.
     tables:
       - type: anndata
         name: table

--- a/src/api/file_spatial_solution.yaml
+++ b/src/api/file_spatial_solution.yaml
@@ -70,6 +70,29 @@ info:
             name: "geometry"
             required: true
             description: Geometry of the nucleus boundary
+      - type: dataframe
+        name: "pa_boundaries"
+        description: >
+          Optional — Portal Area (PA) polygon annotations propagated from the
+          raw common iST dataset.  Present only for liver datasets.  Used by
+          the ASR metric to measure zonal expression gradients.
+        required: false
+        columns:
+          - type: object
+            name: "geometry"
+            required: true
+            description: Geometry of the PA boundary polygon (µm intrinsic coordinates)
+      - type: dataframe
+        name: "cv_boundaries"
+        description: >
+          Optional — Central Vein (CV) polygon annotations propagated from the
+          raw common iST dataset.  Present only for liver datasets.
+        required: false
+        columns:
+          - type: object
+            name: "geometry"
+            required: true
+            description: Geometry of the CV boundary polygon (µm intrinsic coordinates)
     tables:
       - type: anndata
         name: "table"

--- a/src/data_processors/process_dataset/script.py
+++ b/src/data_processors/process_dataset/script.py
@@ -160,7 +160,7 @@ print(">> Building spatial solution (ground truth)", flush=True)
 
 ref_table = sp_data.tables["table"]
 solution_obs = ref_table.obs[["cell_id", "region"]].copy()
-for extra_col in ["cell_area", "transcript_counts"]:
+for extra_col in ["cell_area", "transcript_counts", "groundtruth_cell_type"]:
     if extra_col in ref_table.obs.columns:
         solution_obs[extra_col] = ref_table.obs[extra_col]
 

--- a/src/datasets/loaders/tenx_xenium_groundtruth/script.py
+++ b/src/datasets/loaders/tenx_xenium_groundtruth/script.py
@@ -64,6 +64,35 @@ _ = sdata.images.pop("hne_aligned")
 ## these annotations were derived by Caner Ercan
 sdata.Labels['groundtruth_cell_labels'] = sdata.tables['table'].obs.pop('histoplus_cell_class')
 
+# ── PA / CV Anatomical Landmark Boundaries ────────────────────────────────────
+#
+# Portal Area (PA) and Central Vein (CV) boundaries are optional Polygon shapes
+# manually annotated by a pathologist on the morphology image using QuPath.
+# They encode the two anatomical landmarks of the hepatic lobule:
+#
+#   PA (Portal Area)   — periportal zone; surrounds the portal triad
+#
+#   CV (Central Vein)  — centrilobular zone.
+
+_LANDMARK_SHAPES = (
+    ("pa_boundaries", "Portal Area (PA)"),
+    ("cv_boundaries", "Central Vein (CV)"),
+)
+for _shape_key, _shape_label in _LANDMARK_SHAPES:
+    if _shape_key in sdata.shapes:
+        _n = len(sdata.shapes[_shape_key])
+        print(
+            f"Found {_shape_label} boundaries ({_shape_key}): "
+            f"{_n} polygon(s) — will be propagated to output zarr.",
+            flush=True,
+        )
+    else:
+        print(
+            f"{_shape_label} boundaries ({_shape_key}) NOT present in input zarr.  "
+            f"This is expected for non-liver datasets.  ",
+            flush=True,
+        )
+
 print(f"Output: {sdata}", flush=True)
 
 print(f"Writing to '{par['output']}'", flush=True)

--- a/src/datasets/loaders/tenx_xenium_groundtruth/script.py
+++ b/src/datasets/loaders/tenx_xenium_groundtruth/script.py
@@ -47,7 +47,7 @@ for key, value in new_uns.items():
 
 # add ground truth cell labels
 ## these annotations were derived by Caner Ercan
-sdata.tables["table"].obs["groundtruth_celltype"] = sdata.tables["table"].obs.pop("histoplus_cell_class")
+sdata.tables["table"].obs["groundtruth_cell_type"] = sdata.tables["table"].obs.pop("histoplus_cell_class")
 
 # rename Images
 ## rename raw images to accomodate format

--- a/src/metrics/asr/config.vsh.yaml
+++ b/src/metrics/asr/config.vsh.yaml
@@ -1,0 +1,149 @@
+__merge__: ../../api/comp_metric.yaml
+
+name: asr
+
+label: "Assignment Specificity Ratio"
+
+# One-sentence summary used in benchmark overview tables.
+summary: >
+  Measures transcript mis-assignment in liver segmentation by comparing
+  zonal expression gradients between hepatocytes and sinusoidal endothelial
+  cells relative to Portal Area distance.
+
+# Full description used in documentation and the OpenProblems website.
+description: |
+  The Assignment Specificity Ratio (ASR) evaluates whether a cell-segmentation
+  method correctly assigns hepatocyte transcripts to hepatocytes — rather than
+  letting them "leak" into neighbouring sinusoidal endothelial cells — by
+  exploiting the known periportal-to-centrilobular gene-expression gradient of
+  the liver lobule.
+
+  For each target gene the metric proceeds as follows:
+
+  1. **Distance to PA boundary**: Every predicted cell is assigned a distance
+     to the nearest Portal Area (PA) polygon boundary (in pixel / global
+     coordinate space).  Cells farther than LANDMARK_DIST_THRESHOLD pixels
+     from any landmark are excluded from the regression to avoid fitting noise
+     in the deep parenchyma.
+
+  2. **Cell-type assignment**: Hepatocytes and sinusoidal endothelial cells are
+     identified by mean log-normalised expression of curated marker gene sets
+     (no clustering required).
+
+  3. **OLS gradient regression**: For each cell type, a first-order polynomial
+     (OLS slope β) is fitted to  expression ~ dist_to_PA.
+
+  4. **ASR calculation**:
+
+         ASR = β_hep / (β_sin + ε)
+
+     where β_hep and β_sin are the fitted slopes for hepatocytes and sinusoidal
+     cells respectively, and ε is a small stabilising constant.
+
+     Interpretation:
+       ASR ≫ 1  → gradient is hepatocyte-specific; transcripts are correctly
+                   assigned.
+       ASR ≈ 1  → sinusoidal cells show a gradient of equal strength; the
+                   hepatocyte signal has been mis-assigned.
+       ASR < 1  → the segmentation is catastrophically wrong; sinusoidal cells
+                   carry more signal than hepatocytes.
+
+  One ASR value is returned per gene (metric_ids: ["asr_MET", "asr_CAV1"] by
+  default).
+
+  **IMPORTANT NOTE — dataset specificity (maintainers):**
+  The metric requires pa_boundaries shapes in spatial_solution.zarr, which are
+  present ONLY for liver datasets.  The standard mouse-brain test dataset
+  (resources_test/…/mouse_brain_combined) does NOT have these shapes.  The
+  metric handles this gracefully by writing NaN metric values and exiting
+  cleanly.
+
+references:
+  # Liver zonation biology background
+  doi:
+    - 10.1016/j.cell.2017.02.001     # Halpern et al., 2017 — single-cell zonation atlas
+
+info:
+  metrics:
+    - name: asr_MET
+      label: "ASR — MET"
+      summary: "Assignment Specificity Ratio for MET (hepatocyte/sinusoidal gene)."
+      description: |
+        OLS-based gradient slope ratio (hepatocyte vs sinusoidal) for the gene
+        MET, which encodes a receptor tyrosine kinase expressed in hepatocytes
+        with a mild periportal gradient.  NaN if MET is absent from the gene
+        panel or if too few cells are available for regression.
+      min: -100
+      max: 100
+      maximize: true
+    - name: asr_CAV1
+      label: "ASR — CAV1"
+      summary: "Assignment Specificity Ratio for CAV1 (caveolin-1)."
+      description: |
+        OLS-based gradient slope ratio for CAV1, which is expressed in both
+        hepatocytes and sinusoidal endothelial cells.  A well-calibrated
+        segmentation should show a stronger or equal hepatocyte gradient
+        compared to sinusoidal cells.  NaN if CAV1 is absent or insufficient
+        cells.
+      min: -100
+      max: 100
+      maximize: true
+
+arguments:
+  - name: --genes
+    type: string
+    multiple: true
+    description: |
+      Genes to compute ASR for.  One metric value (metric_id = "asr_{gene}")
+      is emitted per gene.  Genes absent from the prediction gene panel produce
+      NaN metric values.
+    default: ["MET", "CAV1"]
+    info:
+      test_default: ["MET", "CAV1"]
+
+  - name: --epsilon
+    type: double
+    description: |
+      Small constant ε added to β_sin in the denominator of the ASR formula
+      to prevent division by zero when the sinusoidal slope is exactly zero.
+      Default: 1e-6.
+    default: 1.0e-6
+
+  - name: --min_cells
+    type: integer
+    description: |
+      Minimum number of cells of a given type required to fit the OLS
+      regression.  If either hepatocytes or sinusoidal cells fall below this
+      threshold for a gene, that gene's ASR is returned as NaN.
+    default: 10
+
+  - name: --landmark_dist_threshold
+    type: double
+    description: |
+      Maximum distance (in global / pixel coordinate units) from any landmark
+      (PA or CV boundary) for a cell to be included in the gradient regression.
+      Cells farther than this threshold are excluded to avoid fitting expression
+      noise in the deep parenchyma far from both landmarks.
+      Default: 4706 px ≈ 1000 µm at 0.2125 µm/px.
+    default: 4706.0
+
+resources:
+  - type: python_script
+    path: script.py
+
+engines:
+  - type: docker
+    image: openproblems/base_python:1
+    # spatialdata (installed via setup_spatialdata_partial) already brings in
+    # all runtime dependencies:  geopandas, shapely, xarray, dask, anndata.
+    # No additional packages are required beyond the partial merge.
+    __merge__: ../../base/setup_spatialdata_partial.yaml
+  - type: native
+
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      # High time and memory because the metric loads the full-resolution
+      # segmentation label image (up to ~8 GB for full-slide Xenium data).
+      label: [hightime, highmem, midcpu]

--- a/src/metrics/asr/readme.md
+++ b/src/metrics/asr/readme.md
@@ -1,0 +1,30 @@
+
+# Liver zonation anatomical landmark annotations 
+PA (Portal Area) and CV (Central Vein) boundaries are optional Polygon
+shapes manually annotated by a pathologist on the morphology image using
+QuPath.  They encode the two anatomical landmarks of the hepatic lobule:
+
+  PA — periportal zone; surrounds the portal triad (hepatic artery,
+       portal vein, bile duct); Zone 1 gene expression peaks here.
+  CV — centrilobular zone; surrounds the central vein; Zone 3 gene
+       expression peaks here.
+
+Coordinate system: shapes are stored in µm (intrinsic/element space)
+with a scale transform of 1/pixel_size (≈ 4.706 for 0.2125 µm/px
+Xenium data) mapping to the global (pixel) coordinate system — exactly
+the same convention used for cell_boundaries and nucleus_boundaries.
+
+They are consumed downstream by the Assignment Specificity Ratio (ASR)
+metric (src/metrics/asr/) to measure transcript mis-assignment in liver
+segmentation benchmarks by comparing zonal expression gradients between
+hepatocytes and sinusoidal endothelial cells.
+
+IMPORTANT:
+  These shapes are ONLY present for liver datasets that have been
+  prepared with manual annotations.  The standard mouse-brain
+  test dataset (resources_test/…/mouse_brain_combined) does NOT
+  contain pa_boundaries / cv_boundaries.  The ASR metric handles this
+  gracefully (returns NaN), but it means ASR cannot be meaningfully
+  compared across liver and non-liver datasets in the same benchmark
+  run. 
+

--- a/src/metrics/asr/script.py
+++ b/src/metrics/asr/script.py
@@ -1,0 +1,381 @@
+"""
+Assignment Specificity Ratio (ASR) metric.
+
+Measures how specifically a segmentation method assigns hepatocyte transcripts
+to hepatocytes (vs. neighbouring sinusoidal endothelial cells) by comparing the
+zonal gene-expression gradients of the two cell types relative to their distance
+from the nearest Portal Area (PA) boundary in the liver lobule.
+
+Formula
+-------
+For each target gene:
+
+    ASR = β_hep / (β_sin + ε)
+
+where
+    β_hep  = OLS regression slope of hepatocyte log-norm expression vs dist_PA
+    β_sin  = OLS regression slope of sinusoidal log-norm expression vs dist_PA
+    ε      = small stabilising constant (par["epsilon"], default 1e-6)
+
+Interpretation
+--------------
+    ASR ≫ 1  — gradient confined to hepatocytes; correct assignment
+    ASR ≈ 1  — sinusoidal cells show an equal gradient; mis-assignment detected
+    ASR < 1  — catastrophic mis-assignment; sinusoidal cells carry more signal
+
+Inputs
+------
+    input_prediction  : processed_prediction.zarr
+                        (labels/segmentation, tables/table with CxG matrix)
+    input_solution    : spatial_solution.zarr
+                        (shapes/pa_boundaries, shapes/cv_boundaries,
+                         points/transcripts with ground-truth coordinates)
+
+KNOWN ISSUE — dataset specificity
+----------------------------------
+This metric requires pa_boundaries shapes in spatial_solution.zarr.  These are
+present ONLY for liver datasets prepared with liver_zonation/migrate_annotations.py.
+The standard mouse-brain test dataset (resources_test/…/mouse_brain_combined)
+does NOT contain pa_boundaries / cv_boundaries.
+
+The guard block below detects this and writes NaN metric values, allowing the
+metric to run on all benchmark datasets without crashing.  However, NaN scores
+are not meaningful for benchmarking non-liver datasets.
+
+Maintainers: a dataset-specific benchmark configuration or dataset-level filter
+is recommended before full production deployment.  See also:
+  src/api/file_common_ist.yaml   — schema note on pa_boundaries / cv_boundaries
+  src/metrics/asr/config.vsh.yaml — description and KNOWN ISSUE section
+"""
+
+import numpy as np
+import pandas as pd
+import anndata as ad
+import spatialdata as sd
+import xarray as xr
+from shapely.ops import unary_union
+import geopandas as gpd
+
+## VIASH START
+par = {
+    "input_prediction": "resources_test/task_spatial_segmentation/mouse_brain_combined/processed_prediction.zarr",
+    "input_solution":   "resources_test/task_spatial_segmentation/mouse_brain_combined/spatial_solution.zarr",
+    "output":           "output.h5ad",
+    "genes":            ["MET", "CAV1"],
+    "epsilon":          1e-6,
+    "min_cells":        10,
+    "landmark_dist_threshold": 4706.0,   # px ≈ 1000 µm at 0.2125 µm/px
+}
+meta = {
+    "name": "asr"
+}
+## VIASH END
+
+
+# ── Marker gene sets for simple cell-type assignment ─────────────────────────
+# These sets are intentionally small and focused on unambiguous markers so that
+# the scoring works even on panels with a limited number of genes (~300-400
+# is typical for Xenium).  Adjust if the gene panel changes.
+#
+# hepatocyte markers  — periportal to panlobular expression
+HEPATOCYTE_MARKERS = ["ALB", "APOA1", "CYP3A4", "GLUL", "HPX"]
+# sinusoidal endothelial cell markers
+SINUSOIDAL_MARKERS = ["PECAM1", "VWF", "CD34", "FCGR2A"]
+
+MARKER_GROUPS = {
+    "hepatocyte": HEPATOCYTE_MARKERS,
+    "sinusoidal": SINUSOIDAL_MARKERS,
+}
+
+# Minimum mean log-norm expression for a cell type assignment to be kept;
+# cells below this threshold across ALL groups are labelled "unassigned".
+MIN_SCORE_THRESHOLD = 0.05
+
+
+# ── Helper: look up label image values at transcript coordinates ──────────────
+def _lookup_labels(label_element, transcripts_global):
+    """Return label-image values at each transcript's (x, y) position.
+
+    Mirrors the coordinate-handling pattern from metrics/ari/script.py:28-42.
+    Applies the label element's inverse global transform to convert transcript
+    global coordinates to label-array pixel indices, then clips to bounds.
+
+    Parameters
+    ----------
+    label_element     : xr.DataTree | xr.DataArray  — the segmentation labels
+    transcripts_global: dask DataFrame               — transcripts in global CRS
+
+    Returns
+    -------
+    np.ndarray of int  — predicted cell_id per transcript (0 = background)
+    """
+    # Get the inverse transform: global → label intrinsic (pixel indices)
+    trans = sd.transformations.get_transformation(
+        label_element, get_all=True
+    )["global"].inverse()
+    transcripts_local = sd.transform(transcripts_global, trans, "global")
+
+    y = transcripts_local.y.compute().to_numpy(dtype=np.int64)
+    x = transcripts_local.x.compute().to_numpy(dtype=np.int64)
+
+    # Handle multiscale DataTree (use full-resolution scale0)
+    if isinstance(label_element, xr.DataTree):
+        img = label_element["scale0"].image.to_numpy()
+    else:
+        img = label_element.to_numpy()
+
+    # Clip to valid array bounds (guards against floating-point rounding at edges)
+    y = np.clip(y, 0, img.shape[0] - 1)
+    x = np.clip(x, 0, img.shape[1] - 1)
+
+    return img[y, x]
+
+
+# ── Helper: write NaN score file and exit ─────────────────────────────────────
+def _write_nan_output(par, meta, dataset_id, method_id, genes, reason):
+    """Write a well-formed file_score.h5ad with NaN metric values.
+
+    Used when the metric cannot be computed (e.g. no PA/CV shapes in solution,
+    gene not in panel, insufficient cells).  The output still conforms to the
+    file_score.yaml schema so the benchmark pipeline does not fail.
+    """
+    print(f"WARNING: {reason}  Writing NaN metric values.", flush=True)
+    metric_ids    = [f"asr_{g}" for g in genes]
+    metric_values = [float("nan")] * len(genes)
+    output = ad.AnnData(uns={
+        "dataset_id":       dataset_id,
+        "normalization_id": "normalized_log",
+        "method_id":        method_id,
+        "metric_ids":       metric_ids,
+        "metric_values":    metric_values,
+    })
+    output.write_h5ad(par["output"], compression="gzip")
+    print(f"  metric_ids:    {metric_ids}", flush=True)
+    print(f"  metric_values: {metric_values}", flush=True)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main computation
+# ─────────────────────────────────────────────────────────────────────────────
+
+print(">> Reading input files", flush=True)
+sdata_pred = sd.read_zarr(par["input_prediction"])
+sdata_sol  = sd.read_zarr(par["input_solution"])
+
+dataset_id = sdata_sol.tables["table"].uns["dataset_id"]
+method_id  = sdata_pred.tables["table"].uns["method_id"]
+
+# ── Guard: PA/CV shapes must be present in the solution ──────────────────────
+#
+# KNOWN ISSUE: non-liver datasets (e.g. mouse brain) will always hit this path
+# because their spatial_solution.zarr does not contain pa_boundaries.
+# This is intentional graceful degradation.  See module docstring for details.
+if "pa_boundaries" not in sdata_sol.shapes:
+    _write_nan_output(
+        par, meta, dataset_id, method_id, par["genes"],
+        "pa_boundaries not found in spatial_solution.zarr.  "
+        "This is a non-liver dataset, or migrate_annotations.py has not been "
+        "run on the upstream zarr.  ASR requires PA/CV landmark annotations."
+    )
+    raise SystemExit(0)
+
+# ── Build PA union polygon in global (pixel) coordinate space ─────────────────
+# sd.transform with to_coordinate_system="global" applies the shape's scale
+# transform (1/pixel_size ≈ 4.706) and returns geometries in pixel space,
+# consistent with the morphology image and label arrays.
+print(">> Building PA boundary union in global (pixel) space", flush=True)
+pa_global = sd.transform(sdata_sol["pa_boundaries"], to_coordinate_system="global")
+pa_union  = unary_union(pa_global.geometry)
+print(
+    f"   PA union bbox (pixels): "
+    f"x=[{pa_global.geometry.total_bounds[0]:.0f}, {pa_global.geometry.total_bounds[2]:.0f}]  "
+    f"y=[{pa_global.geometry.total_bounds[1]:.0f}, {pa_global.geometry.total_bounds[3]:.0f}]",
+    flush=True,
+)
+
+# ── Load solution transcripts in global (pixel) space ────────────────────────
+# Transcript coordinates from spatial_solution are used to:
+#   (a) look up the predicted cell_id in the segmentation label image, and
+#   (b) compute per-cell centroid as the mean (x, y) of its transcripts.
+# This avoids loading a second copy of the label image for regionprops and
+# is consistent with how metrics/ari/script.py handles coordinates.
+print(">> Loading solution transcripts in global space", flush=True)
+transcripts_global = sd.transform(
+    sdata_sol["transcripts"], to_coordinate_system="global"
+)
+
+# ── Look up predicted cell ID for each transcript ─────────────────────────────
+# Applies the inverse of the segmentation's global transform so that transcript
+# global coordinates become pixel indices into the label array.
+print(">> Looking up predicted cell IDs from segmentation label image", flush=True)
+pred_cell_ids = _lookup_labels(sdata_pred["segmentation"], transcripts_global)
+
+# ── Compute per-transcript global (x, y) and distance to nearest PA boundary ──
+print(">> Computing PA boundary distances for each transcript", flush=True)
+tx = transcripts_global.x.compute().to_numpy()   # global x (pixels)
+ty = transcripts_global.y.compute().to_numpy()   # global y (pixels)
+
+# geopandas GeoSeries.distance() uses vectorised GEOS distance — far faster
+# than a Python Shapely loop over millions of transcripts.
+trans_points  = gpd.GeoSeries.from_xy(pd.Series(tx), pd.Series(ty))
+dist_pa_trans = trans_points.distance(pa_union).to_numpy()
+
+# ── Aggregate transcripts to cell level ───────────────────────────────────────
+# For each predicted cell:
+#   - centroid (cx, cy) = mean transcript (x, y)  [in global / pixel units]
+#   - dist_pa           = mean transcript distance to PA boundary
+#                         (good approximation to centroid distance for typical
+#                          hepatocyte sizes ~20-40 µm)
+print(">> Aggregating transcripts to per-cell summaries", flush=True)
+trans_df = pd.DataFrame({
+    "cell_id": pred_cell_ids,
+    "x":       tx,
+    "y":       ty,
+    "dist_pa": dist_pa_trans,
+})
+# Drop background (cell_id == 0 means the transcript was not assigned to any cell)
+trans_df = trans_df[trans_df["cell_id"] != 0]
+
+cell_df = trans_df.groupby("cell_id").agg(
+    cx      = ("x",       "mean"),
+    cy      = ("y",       "mean"),
+    dist_pa = ("dist_pa", "mean"),
+).reset_index()
+
+print(f"   Predicted cells with ≥1 transcript: {len(cell_df):,}", flush=True)
+
+# ── Merge with expression table ───────────────────────────────────────────────
+# processed_prediction table obs["cell_id"] is a string; cell_df["cell_id"] is
+# an integer from the label image.  Convert for the join.
+print(">> Merging with expression table", flush=True)
+table = sdata_pred.tables["table"]
+
+cell_df["cell_id_str"] = cell_df["cell_id"].astype(str)
+obs_df = table.obs[["cell_id"]].copy()    # cell_id as string
+
+merged = obs_df.merge(
+    cell_df[["cell_id_str", "dist_pa"]],
+    left_on="cell_id", right_on="cell_id_str",
+    how="left",
+)
+merged.index = obs_df.index    # preserve AnnData obs index alignment
+
+dist_all = merged["dist_pa"].to_numpy(dtype=float)   # NaN for cells with no transcripts
+
+# ── Assign cell types from marker gene scores ─────────────────────────────────
+# Uses mean log-normalised expression of curated marker sets.
+# No clustering: straightforward, fast, works on any gene panel size.
+# Falls back to "unassigned" for cells below MIN_SCORE_THRESHOLD.
+print(">> Assigning cell types from marker gene scores", flush=True)
+
+# Extract log-normalised expression matrix as a dense DataFrame (cells × genes)
+lognorm = table.layers["normalized_log"]
+if hasattr(lognorm, "toarray"):
+    lognorm = lognorm.toarray()
+else:
+    lognorm = np.array(lognorm)
+
+expr_df = pd.DataFrame(lognorm, index=table.obs_names, columns=table.var_names)
+
+scores = {}
+for ct, markers in MARKER_GROUPS.items():
+    avail = [m for m in markers if m in expr_df.columns]
+    missing = [m for m in markers if m not in expr_df.columns]
+    if missing:
+        print(f"   {ct}: {len(avail)} markers available, missing: {missing}", flush=True)
+    if avail:
+        scores[ct] = expr_df[avail].mean(axis=1)
+    else:
+        print(f"   WARNING: no markers available for '{ct}' — assigning score 0.", flush=True)
+        scores[ct] = pd.Series(0.0, index=expr_df.index)
+
+score_df  = pd.DataFrame(scores)
+cell_type = score_df.idxmax(axis=1)
+max_score = score_df.max(axis=1)
+cell_type[max_score < MIN_SCORE_THRESHOLD] = "unassigned"
+
+hep_mask = (cell_type == "hepatocyte").to_numpy()
+sin_mask = (cell_type == "sinusoidal").to_numpy()
+
+n_hep = hep_mask.sum()
+n_sin = sin_mask.sum()
+print(f"   Hepatocytes: {n_hep:,}   Sinusoidal: {n_sin:,}", flush=True)
+
+# ── Compute ASR per gene ───────────────────────────────────────────────────────
+print(">> Computing ASR per gene", flush=True)
+
+metric_ids    = []
+metric_values = []
+
+for gene in par["genes"]:
+    metric_ids.append(f"asr_{gene}")
+
+    # Gene not in gene panel → NaN
+    if gene not in expr_df.columns:
+        print(f"   {gene}: absent from gene panel — NaN", flush=True)
+        metric_values.append(float("nan"))
+        continue
+
+    gene_expr = expr_df[gene].to_numpy()
+
+    slopes = {}
+    for ct_label, mask in [("hepatocyte", hep_mask), ("sinusoidal", sin_mask)]:
+        # Restrict to cells that:
+        #   (a) belong to this cell type
+        #   (b) have a valid (non-NaN) PA distance
+        #   (c) are within the landmark distance threshold
+        valid = (
+            mask
+            & np.isfinite(dist_all)
+            & (dist_all <= par["landmark_dist_threshold"])
+        )
+        n = int(valid.sum())
+
+        if n < par["min_cells"]:
+            print(
+                f"   {gene}/{ct_label}: only {n} cells within threshold "
+                f"(need ≥ {par['min_cells']}) — NaN slope",
+                flush=True,
+            )
+            slopes[ct_label] = None
+        else:
+            d = dist_all[valid]
+            e = gene_expr[valid]
+            # np.polyfit returns [slope, intercept] for degree-1 polynomial
+            slope = float(np.polyfit(d, e, 1)[0])
+            slopes[ct_label] = slope
+            print(
+                f"   {gene}/{ct_label}: slope = {slope:.6f}  n = {n:,}",
+                flush=True,
+            )
+
+    slope_hep = slopes.get("hepatocyte")
+    slope_sin = slopes.get("sinusoidal")
+
+    if slope_hep is None or slope_sin is None:
+        # Insufficient cells for one or both types
+        asr = float("nan")
+    else:
+        # Core ASR formula:  β_hep / (β_sin + ε)
+        asr = slope_hep / (slope_sin + par["epsilon"])
+
+    print(f"   {gene}: ASR = {asr}", flush=True)
+    metric_values.append(float(asr) if np.isfinite(asr) else float("nan"))
+
+# ── Write score file ──────────────────────────────────────────────────────────
+# Output conforms to file_score.yaml:
+#   uns.dataset_id, uns.normalization_id, uns.method_id,
+#   uns.metric_ids (list[str]), uns.metric_values (list[float])
+print(">> Writing output score file", flush=True)
+output = ad.AnnData(uns={
+    "dataset_id":       dataset_id,
+    "normalization_id": "normalized_log",
+    "method_id":        method_id,
+    "metric_ids":       metric_ids,
+    "metric_values":    metric_values,
+})
+output.write_h5ad(par["output"], compression="gzip")
+
+print("Done.", flush=True)
+print(f"  metric_ids:    {metric_ids}",    flush=True)
+print(f"  metric_values: {metric_values}", flush=True)

--- a/src/metrics/marker_specificity/config.vsh.yaml
+++ b/src/metrics/marker_specificity/config.vsh.yaml
@@ -1,0 +1,43 @@
+__merge__: ../../api/comp_metric.yaml
+
+name: cell_type_superset_specificity
+
+label: "Cell Cell type superset specificity"
+summary: >
+  Fraction of predicted cells that express markers from exactly one
+  ground-truth super-class, indicating correct transcript assignment.
+description: |
+  The cell's raw transcript counts are then checked
+  against four marker gene groups (Tumour_Epithelial, Immune, Fibroblast,
+  Endothelial). A cell is Specific if exactly one group has any detected
+  marker, Ambiguous if more than one group does, and Negative if none do.
+  The primary score is the overall Specific fraction across all predicted
+  cells with a valid GT class assignment.
+
+  Returns NaN when groundtruth_cell_type is absent from spatial_solution
+  (i.e. the dataset was not loaded with tenx_xenium_groundtruth).
+
+info:
+  metrics:
+    - name: cell_type_superset_specificity
+      label: "Cell type superset specificity"
+      summary: "Fraction of predicted cells with exactly one marker super-class detected."
+      min: 0
+      max: 1
+      maximize: true
+
+resources:
+  - type: python_script
+    path: script.py
+
+engines:
+  - type: docker
+    image: openproblems/base_python:1
+    __merge__: ../../base/setup_spatialdata_partial.yaml
+  - type: native
+
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      label: [hightime, highmem, midcpu]

--- a/src/metrics/marker_specificity/script.py
+++ b/src/metrics/marker_specificity/script.py
@@ -1,0 +1,139 @@
+import numpy as np
+import pandas as pd
+import anndata as ad
+import spatialdata as sd
+
+## VIASH START
+par = {
+    "input_prediction": "resources_test/task_spatial_segmentation/mouse_brain_combined/processed_prediction.zarr",
+    "input_solution":   "resources_test/task_spatial_segmentation/mouse_brain_combined/spatial_solution.zarr",
+    "output":           "output.h5ad",
+}
+meta = {
+    "name": "marker_specificity"
+}
+## VIASH END
+
+MARKERS = {
+    "Tumour_Epithelial": [
+        "EPCAM", "CDH1", "TACSTD2", "CD24", "SFN", "PERP", "PKP1", "JUP", "DSP",
+        "KRT5", "KRT6A", "KRT7", "KRT8", "KRT10", "KRT13", "KRT14", "KRT16",
+        "KRT17", "KRT18", "KRT19", "TP63", "DSG3", "EGFR",
+    ],
+    "Immune": [
+        "PTPRC", "CD3D", "CD3E", "CD3G", "CD4", "CD8A", "CD8B", "TRAC",
+        "CD79A", "CD79B", "MS4A1", "MZB1", "JCHAIN", "IGHA1", "IGHG1", "IGHM",
+        "NKG7", "GNLY", "KLRD1", "KLRB1",
+        "CD68", "CD163", "C1QA", "C1QB", "C1QC", "CSF1R", "MRC1", "ITGAM", "ITGAX",
+        "CSF3R", "FCGR3B", "CEACAM8", "CXCR2",
+        "CLC", "SIGLEC8", "RNASE2", "EPX",
+        "TPSAB1", "CPA3", "CD1C", "CLEC9A",
+    ],
+    "Fibroblast": [
+        "COL1A1", "COL1A2", "COL3A1", "COL5A1", "COL5A2", "COL6A1", "COL6A2", "COL6A3",
+        "DCN", "LUM", "PDGFRA", "PDGFRB", "FAP", "POSTN", "BGN", "CCDC80",
+        "FBLN1", "FBLN2", "VCAN", "LOXL1", "ACTA2", "RGS5", "MCAM",
+    ],
+    "Endothelial": [
+        "PECAM1", "VWF", "CLDN5", "CDH5", "ERG", "FLT1", "KDR", "TIE1", "TEK",
+        "ENG", "NOS3", "MMRN1", "PLVAP", "ROBO4", "ESM1", "ACVRL1", "SOX17", "ACKR1",
+    ],
+}
+
+CLASS_TO_SUPERCLASS = {
+    "Cancer cell":        "Tumour_Epithelial",
+    "Mitotic Figures":    "Tumour_Epithelial",
+    "Epithelial":         "Tumour_Epithelial",
+    "Lymphocytes":        "Immune",
+    "Plasmocytes":        "Immune",
+    "Eosinophils":        "Immune",
+    "Neutrophils":        "Immune",
+    "Macrophages":        "Immune",
+    "Fibroblasts":        "Fibroblast",
+    "Minor Stromal Cell": "Fibroblast",
+    "Endothelial Cell":   "Endothelial",
+}
+
+
+def _write_nan(par, dataset_id, method_id, reason):
+    print(f"WARNING: {reason}  Writing NaN.", flush=True)
+    ad.AnnData(uns={
+        "dataset_id":       dataset_id,
+        "normalization_id": "counts",
+        "method_id":        method_id,
+        "metric_ids":       ["marker_specificity"],
+        "metric_values":    [float("nan")],
+    }).write_h5ad(par["output"], compression="gzip")
+
+
+print(">> Reading inputs", flush=True)
+sdata_pred = sd.read_zarr(par["input_prediction"])
+sdata_sol  = sd.read_zarr(par["input_solution"])
+
+dataset_id = sdata_pred.tables["table"].uns["dataset_id"]
+method_id  = sdata_pred.tables["table"].uns["method_id"]
+
+sol_obs = sdata_sol.tables["table"].obs
+if "groundtruth_cell_type" not in sol_obs.columns:
+    _write_nan(par, dataset_id, method_id,
+               "groundtruth_cell_type not found in spatial_solution.")
+    raise SystemExit(0)
+
+# Cell IDs with a mapped GT class
+mapped_obs = sol_obs[sol_obs["groundtruth_cell_type"].isin(CLASS_TO_SUPERCLASS)]
+valid_ids   = set(mapped_obs["cell_id"].values)
+
+if not valid_ids:
+    _write_nan(par, dataset_id, method_id, "No GT cells with a mapped class.")
+    raise SystemExit(0)
+
+# Build per-GT-cell count matrix from solution transcripts
+print(">> Building GT cell expression from solution transcripts", flush=True)
+tx = sdata_sol["transcripts"][["cell_id", "feature_name"]].compute()
+tx = tx[(tx["cell_id"] != 0) & (tx["cell_id"].isin(valid_ids))]
+
+if tx.empty:
+    _write_nan(par, dataset_id, method_id, "No transcripts for mapped GT cells.")
+    raise SystemExit(0)
+
+counts_df = tx.groupby(["cell_id", "feature_name"]).size().unstack(fill_value=0)
+panel     = set(counts_df.columns)
+col_idx   = {g: i for i, g in enumerate(counts_df.columns)}
+counts_arr = counts_df.values
+
+# Filter marker genes to those present in the panel
+marker_panel = {}
+for sc, genes in MARKERS.items():
+    in_panel = [g for g in genes if g in panel]
+    marker_panel[sc] = in_panel
+    n_miss = len(genes) - len(in_panel)
+    if n_miss:
+        print(f"   {sc}: {n_miss}/{len(genes)} marker genes absent from panel", flush=True)
+
+# Count how many groups have ≥1 expressed gene per cell
+print(">> Evaluating marker groups", flush=True)
+n_groups = np.zeros(len(counts_df), dtype=np.int8)
+for sc, genes in marker_panel.items():
+    if genes:
+        idxs = [col_idx[g] for g in genes]
+        n_groups += (counts_arr[:, idxs] > 0).any(axis=1).astype(np.int8)
+
+n         = len(counts_df)
+specific  = float((n_groups == 1).sum() / n)
+ambiguous = float((n_groups >  1).sum() / n)
+negative  = float((n_groups == 0).sum() / n)
+
+print(
+    f">> n={n:,}  Specific={specific:.3f}  "
+    f"Ambiguous={ambiguous:.3f}  Negative={negative:.3f}",
+    flush=True,
+)
+
+print(">> Writing output", flush=True)
+ad.AnnData(uns={
+    "dataset_id":       dataset_id,
+    "normalization_id": "counts",
+    "method_id":        method_id,
+    "metric_ids":       ["marker_specificity"],
+    "metric_values":    [specific],
+}).write_h5ad(par["output"], compression="gzip")

--- a/src/metrics/mitotic_specificity/config.vsh.yaml
+++ b/src/metrics/mitotic_specificity/config.vsh.yaml
@@ -1,0 +1,60 @@
+__merge__: ../../api/comp_metric.yaml
+
+name: mitotic_specificity
+
+label: "Mitotic Cell Marker Specificity"
+summary: >
+  Evaluates transcriptome assignment accuracy for mitotic cells by measuring
+  how specifically mitotic-marker transcripts are confined to mitotic GT cells.
+description: |
+  Using ground-truth cell assignments from spatial_solution transcripts, builds
+  a per-GT-cell count matrix for cells annotated as "Mitotic Figures" or
+  "Cancer cell". Three complementary metrics are computed:
+
+  - mitotic_sensitivity: fraction of mitotic GT cells expressing ≥1 mitosis-
+    specific gene. Normalised by total mitotic cell count.
+  - mitotic_specificity: fraction of non-mitotic GT cells expressing zero
+    mitosis-specific genes. Tests that mitotic signal does not leak into
+    cancer cells.
+  - nonmitotic_purity: fraction of mitotic GT cells expressing zero
+    non-mitosis-specific genes (negative metric — non-mitotic signal in
+    mitotic cells indicates mis-assignment contamination).
+
+  Returns NaN when groundtruth_cell_type is absent from spatial_solution.
+
+info:
+  metrics:
+    - name: mitotic_sensitivity
+      label: "Mitotic Sensitivity"
+      summary: "Fraction of mitotic GT cells with ≥1 mitosis-specific gene detected."
+      min: 0
+      max: 1
+      maximize: true
+    - name: mitotic_specificity
+      label: "Mitotic Specificity"
+      summary: "Fraction of non-mitotic GT cells with zero mitosis-specific genes."
+      min: 0
+      max: 1
+      maximize: true
+    - name: nonmitotic_purity
+      label: "Non-mitotic Purity"
+      summary: "Fraction of mitotic GT cells free of non-mitosis-specific genes."
+      min: 0
+      max: 1
+      maximize: true
+
+resources:
+  - type: python_script
+    path: script.py
+
+engines:
+  - type: docker
+    image: openproblems/base_python:1
+    __merge__: ../../base/setup_spatialdata_partial.yaml
+  - type: native
+
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      label: [midtime, midmem, midcpu]

--- a/src/metrics/mitotic_specificity/script.py
+++ b/src/metrics/mitotic_specificity/script.py
@@ -1,0 +1,150 @@
+import numpy as np
+import pandas as pd
+import anndata as ad
+import spatialdata as sd
+
+## VIASH START
+par = {
+    "input_prediction": "resources_test/task_spatial_segmentation/mouse_brain_combined/processed_prediction.zarr",
+    "input_solution":   "resources_test/task_spatial_segmentation/mouse_brain_combined/spatial_solution.zarr",
+    "output":           "output.h5ad",
+}
+meta = {
+    "name": "mitotic_specificity"
+}
+## VIASH END
+
+MARKERS = {
+    "Mitosis_specific": [
+        "AURKB", "PLK1", "CENPF", "BUB1", "MAD2L1", "PRC1", "KIF23",
+        "AURKA", "MKLP1",
+    ],
+    "Non_mitosis_specific": [
+        "CCND1", "CDKN1A", "CDKN1B", "GAS1", "NEAT1", "MALAT1", "RB1",
+    ],
+}
+
+CLASS_TO_MAP = {
+    "Cancer cell":     "non_mitotic",
+    "Mitotic Figures": "mitotic",
+}
+
+METRIC_IDS = ["mitotic_sensitivity", "mitotic_specificity", "nonmitotic_purity"]
+
+
+def _write_nan(par, dataset_id, method_id, reason):
+    print(f"WARNING: {reason}  Writing NaN.", flush=True)
+    ad.AnnData(uns={
+        "dataset_id":       dataset_id,
+        "normalization_id": "counts",
+        "method_id":        method_id,
+        "metric_ids":       METRIC_IDS,
+        "metric_values":    [float("nan")] * len(METRIC_IDS),
+    }).write_h5ad(par["output"], compression="gzip")
+
+
+print(">> Reading inputs", flush=True)
+sdata_pred = sd.read_zarr(par["input_prediction"])
+sdata_sol  = sd.read_zarr(par["input_solution"])
+
+dataset_id = sdata_pred.tables["table"].uns["dataset_id"]
+method_id  = sdata_pred.tables["table"].uns["method_id"]
+
+sol_obs = sdata_sol.tables["table"].obs
+if "groundtruth_cell_type" not in sol_obs.columns:
+    _write_nan(par, dataset_id, method_id,
+               "groundtruth_cell_type not found in spatial_solution.")
+    raise SystemExit(0)
+
+# Map GT cells to mitotic / non_mitotic; exclude unmapped classes
+mapped_obs = sol_obs[sol_obs["groundtruth_cell_type"].isin(CLASS_TO_MAP)].copy()
+mapped_obs["group"] = mapped_obs["groundtruth_cell_type"].map(CLASS_TO_MAP)
+id_to_group = mapped_obs.set_index("cell_id")["group"].to_dict()
+
+if not id_to_group:
+    _write_nan(par, dataset_id, method_id,
+               "No GT cells mapped to mitotic/non_mitotic classes.")
+    raise SystemExit(0)
+
+# Build per-GT-cell count matrix from solution transcripts
+print(">> Building GT cell expression from solution transcripts", flush=True)
+tx = sdata_sol["transcripts"][["cell_id", "feature_name"]].compute()
+tx = tx[(tx["cell_id"] != 0) & (tx["cell_id"].isin(id_to_group))]
+
+if tx.empty:
+    _write_nan(par, dataset_id, method_id,
+               "No transcripts found for mapped GT cells.")
+    raise SystemExit(0)
+
+counts_df  = tx.groupby(["cell_id", "feature_name"]).size().unstack(fill_value=0)
+panel      = set(counts_df.columns)
+col_idx    = {g: i for i, g in enumerate(counts_df.columns)}
+counts_arr = counts_df.values
+
+# Filter each marker group to genes present in the panel
+marker_panel = {}
+for grp, genes in MARKERS.items():
+    in_panel = [g for g in genes if g in panel]
+    marker_panel[grp] = in_panel
+    n_miss = len(genes) - len(in_panel)
+    if n_miss:
+        print(f"   {grp}: {n_miss}/{len(genes)} genes absent from panel", flush=True)
+
+# Boolean arrays per marker group (one value per GT cell row)
+def _any_expressed(genes):
+    if not genes:
+        return np.zeros(len(counts_df), dtype=bool)
+    idxs = [col_idx[g] for g in genes]
+    return (counts_arr[:, idxs] > 0).any(axis=1)
+
+print(">> Evaluating marker groups", flush=True)
+mitotic_expr     = _any_expressed(marker_panel["Mitosis_specific"])
+nonmitotic_expr  = _any_expressed(marker_panel["Non_mitosis_specific"])
+
+# Cell group membership arrays aligned to counts_df index
+groups = np.array([id_to_group[cid] for cid in counts_df.index])
+is_mitotic     = groups == "mitotic"
+is_nonmitotic  = groups == "non_mitotic"
+
+n_mitotic    = is_mitotic.sum()
+n_nonmitotic = is_nonmitotic.sum()
+
+print(f"   Mitotic GT cells:     {n_mitotic:,}", flush=True)
+print(f"   Non-mitotic GT cells: {n_nonmitotic:,}", flush=True)
+
+def _safe_frac(num, denom):
+    return float(num / denom) if denom > 0 else float("nan")
+
+# mitotic_sensitivity: fraction of mitotic cells expressing ≥1 mitotic gene
+#   normalised by total mitotic cell count
+mitotic_sensitivity = _safe_frac(
+    (is_mitotic & mitotic_expr).sum(), n_mitotic
+)
+
+# mitotic_specificity: fraction of non-mitotic cells expressing zero mitotic genes
+#   mitotic signal should not leak into cancer cells
+mitotic_specificity = _safe_frac(
+    (is_nonmitotic & ~mitotic_expr).sum(), n_nonmitotic
+)
+
+# nonmitotic_purity: fraction of mitotic cells expressing zero non-mitotic genes
+#   non-mitotic signal in mitotic cells indicates mis-assignment contamination
+nonmitotic_purity = _safe_frac(
+    (is_mitotic & ~nonmitotic_expr).sum(), n_mitotic
+)
+
+print(
+    f">> mitotic_sensitivity={mitotic_sensitivity:.3f}  "
+    f"mitotic_specificity={mitotic_specificity:.3f}  "
+    f"nonmitotic_purity={nonmitotic_purity:.3f}",
+    flush=True,
+)
+
+print(">> Writing output", flush=True)
+ad.AnnData(uns={
+    "dataset_id":       dataset_id,
+    "normalization_id": "counts",
+    "method_id":        method_id,
+    "metric_ids":       METRIC_IDS,
+    "metric_values":    [mitotic_sensitivity, mitotic_specificity, nonmitotic_purity],
+}).write_h5ad(par["output"], compression="gzip")

--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -71,6 +71,7 @@ dependencies:
   - name: methods/segger
   - name: data_processors/cell_type_annotation_tacco
   - name: metrics/ari
+  - name: metrics/asr
   - name: data_processors/process_prediction
 
 runners:

--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -72,6 +72,8 @@ dependencies:
   - name: data_processors/cell_type_annotation_tacco
   - name: metrics/ari
   - name: metrics/asr
+  - name: metrics/marker_specificity
+  - name: metrics/mitotic_specificity
   - name: data_processors/process_prediction
 
 runners:

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -18,8 +18,15 @@ methods = [
 ]
 
 // construct list of metrics
+// NOTE: asr (Assignment Specificity Ratio) requires pa_boundaries / cv_boundaries
+// shapes in spatial_solution.zarr.  These are present only for liver datasets
+// prepared with liver_zonation/migrate_annotations.py.  On non-liver datasets
+// (including the mouse-brain test data) asr will write NaN metric values and
+// exit cleanly without crashing the pipeline.  See src/metrics/asr/script.py
+// and src/api/file_common_ist.yaml.
 metrics = [
-  ari
+  ari,
+  asr
 ]
 
 workflow run_wf {

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -26,7 +26,9 @@ methods = [
 // and src/api/file_common_ist.yaml.
 metrics = [
   ari,
-  asr
+  asr,
+  marker_specificity,
+  mitotic_specificity
 ]
 
 workflow run_wf {


### PR DESCRIPTION
## Describe your changes

Adds three new evaluation metrics to the `run_benchmark` workflow:

- **ASR (Assignment Specificity Ratio)** — Liver zonation metric evaluating whether segmentation correctly assigns hepatocyte transcripts to hepatocytes vs. sinusoidal endothelial cells, using PA-distance gradients. Returns `asr_MET` and `asr_CAV1`. Gracefully returns NaN for non-liver datasets.
- **Marker Specificity** — Fraction of predicted cells expressing markers from exactly one GT super-class (Tumour_Epithelial, Immune, Fibroblast, Endothelial).
- **Mitotic Specificity** — Three metrics: `mitotic_sensitivity`, `mitotic_specificity`, `nonmitotic_purity`, evaluating transcript assignment for mitotic vs. non-mitotic GT cells.

Also fixes `groundtruth_cell_type` naming in the Xenium groundtruth loader and propagates it through `process_dataset`.

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [x] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!